### PR TITLE
fix: CIからRun buildを削除

### DIFF
--- a/.github/workflows/pull-request-check.yaml
+++ b/.github/workflows/pull-request-check.yaml
@@ -27,14 +27,3 @@ jobs:
         uses: ./.github/actions/setup
       - name: Run tests
         run: npm run test
-
-  build:
-    name: Run build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Setup
-        uses: ./.github/actions/setup
-      - name: Run build
-        run: npm run build


### PR DESCRIPTION
## Issue <!-- 関連するIssue -->

## 対応内容 <!-- やったことを簡潔に -->

Vercelがbuiildとデプロイを行うのでCIからRun buildを削除

## この PR でやらないこと

## 関連資料 <!-- 仕様書等、PRレビューに役立つ資料のリンク -->

## スクショ(Optional)

## 影響範囲 <!-- この変更によって影響するページなど -->

## レビュー観点 <!-- このPRで特に注視して確認して欲しいこと -->

## その他