### PR TITLE
db studioとprettierのsetup

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,7 +11,7 @@ const compat = new FlatCompat({
 });
 
 const eslintConfig = [
-  ...compat.extends('next/core-web-vitals', 'next/typescript'),
+  ...compat.extends('next/core-web-vitals', 'next/typescript', 'prettier'),
   {
     plugins: {
       drizzle,

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,9 @@
         "drizzle-kit": "^0.31.1",
         "eslint": "^9",
         "eslint-config-next": "15.3.0",
+        "eslint-config-prettier": "^10.1.5",
         "eslint-plugin-drizzle": "^0.2.3",
+        "prettier": "^3.5.3",
         "tailwindcss": "^4",
         "tsx": "^4.19.4",
         "tw-animate-css": "^1.3.0",
@@ -4343,6 +4345,22 @@
         }
       }
     },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.5",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.5.tgz",
+      "integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
     "node_modules/eslint-import-resolver-node": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
@@ -6536,6 +6554,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prop-types": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "migration:push": "drizzle-kit push",
     "migration:apply": "drizzle-kit migrate",
     "migration:drop": "drizzle-kit drop",
-    "db:studio": "drizzle-kit studio"
+    "db:studio": "drizzle-kit studio",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "dependencies": {
     "@radix-ui/react-label": "^2.1.7",
@@ -42,7 +44,9 @@
     "drizzle-kit": "^0.31.1",
     "eslint": "^9",
     "eslint-config-next": "15.3.0",
+    "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-drizzle": "^0.2.3",
+    "prettier": "^3.5.3",
     "tailwindcss": "^4",
     "tsx": "^4.19.4",
     "tw-animate-css": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "migration:generate": "drizzle-kit generate",
     "migration:push": "drizzle-kit push",
     "migration:apply": "drizzle-kit migrate",
-    "migration:drop": "drizzle-kit drop"
+    "migration:drop": "drizzle-kit drop",
+    "db:studio": "drizzle-kit studio"
   },
   "dependencies": {
     "@radix-ui/react-label": "^2.1.7",


### PR DESCRIPTION
## Issue <!-- 関連するIssue -->

なし

## 対応内容 <!-- やったことを簡潔に -->
開発環境の改善
- drizzle db studioを利用できるようにした
- prettierを利用できるようにした

## この PR でやらないこと
- prettierによるコード整形の実行
    - 差分が多すぎるので、コード整形を実行するだけのPRを別で作成します。 

## 関連資料 <!-- 仕様書等、PRレビューに役立つ資料のリンク -->
eslint x prettier
https://nextjs.org/docs/app/api-reference/config/eslint#with-prettier

drizzle db studio
https://orm.drizzle.team/drizzle-studio/overview

## スクショ(Optional)

prettierによるformat check

```sh
shota_furuno@Shotas-Mac-mini praha-challenge-agile-dev % npm run format:check

> praha-challenge-agile-dev@0.1.0 format:check
> prettier --check .

Checking formatting...
[warn] .github/actions/setup/action.yaml
[warn] .github/ISSUE_TEMPLATE/bug_report.md
[warn] .github/ISSUE_TEMPLATE/task.md
[warn] .github/pull_request_template.md
[warn] components.json
[warn] drizzle.config.ts
[warn] drizzle/meta/_journal.json
[warn] drizzle/meta/0000_snapshot.json
[warn] eslint.config.mjs
[warn] README.md
[warn] src/actions/sign-in.ts
[warn] src/app/error/page.tsx
[warn] src/app/sign-in/page.tsx
[warn] src/components/organisms/sign-in/sign-in-form.tsx
[warn] src/components/ui/button.tsx
[warn] src/components/ui/card.tsx
[warn] src/components/ui/input.tsx
[warn] src/components/ui/label.tsx
[warn] src/infra/db.ts
[warn] src/infra/schema.ts
[warn] src/infra/supabase/client.ts
[warn] src/infra/supabase/middleware.ts
[warn] src/infra/supabase/server.ts
[warn] src/infra/supabase/sign-in.ts
[warn] src/lib/utils.ts
[warn] src/middleware.ts
[warn] src/test-example/test-example.spec.ts
[warn] src/usecases/sign-in/SignInUsecase.ts
[warn] src/validations/emailSchema.ts
[warn] src/validations/passwordSchema.ts
[warn] src/validations/signInSchema.ts
[warn] Code style issues found in 31 files. Run Prettier with --write to fix.
```

drizzle db studio

```sh
shota_furuno@Shotas-Mac-mini praha-challenge-agile-dev % npm run db:studio                            

> praha-challenge-agile-dev@0.1.0 db:studio
> drizzle-kit studio

No config path provided, using default 'drizzle.config.ts'
Reading config file '/Users/shota_furuno/Documents/GitHub/praha-challenge-agile-dev/drizzle.config.ts'
Using 'postgres' driver for database querying

 Warning  Drizzle Studio is currently in Beta. If you find anything that is not working as expected or should be improved, feel free to create an issue on GitHub: https://github.com/drizzle-team/drizzle-kit-mirror/issues/new or write to us on Discord: https://discord.gg/WcRKz2FFxN

Drizzle Studio is up and running on https://local.drizzle.studio
```

<img width="1683" alt="Screenshot 2025-05-27 at 22 50 08" src="https://github.com/user-attachments/assets/fab32078-4abf-46e4-8290-245ac68583f5" />


## 影響範囲 <!-- この変更によって影響するページなど -->
特になし

## レビュー観点 <!-- このPRで特に注視して確認して欲しいこと -->
設定が適切か

## その他