### PR TITLE
課題公開ステータス変更画面のUI実装

### DIFF
--- a/drizzle/0003_clean_warbound.sql
+++ b/drizzle/0003_clean_warbound.sql
@@ -1,0 +1,19 @@
+CREATE TABLE "seasons" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"name" varchar(100) NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "teams" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"name" varchar(255) NOT NULL,
+	"season_id" uuid NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "team_id" uuid NOT NULL;--> statement-breakpoint
+ALTER TABLE "teams" ADD CONSTRAINT "teams_season_id_seasons_id_fk" FOREIGN KEY ("season_id") REFERENCES "public"."seasons"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "users" ADD CONSTRAINT "users_team_id_teams_id_fk" FOREIGN KEY ("team_id") REFERENCES "public"."teams"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "users" DROP COLUMN "season";

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,519 @@
+{
+  "id": "a553c302-5b5d-40f2-9ede-b30aa085ad19",
+  "prevId": "68becedd-0657-4fdc-ae4e-0a21786d98e9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.assignment_status": {
+      "name": "assignment_status",
+      "schema": "",
+      "columns": {
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assignments": {
+      "name": "assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre": {
+          "name": "genre",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "assignments_genre_genre_name_fk": {
+          "name": "assignments_genre_genre_name_fk",
+          "tableFrom": "assignments",
+          "tableTo": "genre",
+          "columnsFrom": [
+            "genre"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.genre": {
+      "name": "genre",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.new_assignment_public_requests": {
+      "name": "new_assignment_public_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "new_assignment_public_requests_user_id_users_id_fk": {
+          "name": "new_assignment_public_requests_user_id_users_id_fk",
+          "tableFrom": "new_assignment_public_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "assignment_public_requests_status_fkey": {
+          "name": "assignment_public_requests_status_fkey",
+          "tableFrom": "new_assignment_public_requests",
+          "tableTo": "new_assignment_status",
+          "columnsFrom": [
+            "status"
+          ],
+          "columnsTo": [
+            "status"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.new_assignment_status": {
+      "name": "new_assignment_status",
+      "schema": "",
+      "columns": {
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.seasons": {
+      "name": "seasons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teams_season_id_seasons_id_fk": {
+          "name": "teams_season_id_seasons_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "seasons",
+          "columnsFrom": [
+            "season_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_assignments": {
+      "name": "users_assignments",
+      "schema": "",
+      "columns": {
+        "users_id": {
+          "name": "users_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignments_id": {
+          "name": "assignments_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_assignments_users_id_users_id_fk": {
+          "name": "users_assignments_users_id_users_id_fk",
+          "tableFrom": "users_assignments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "users_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_assignments_assignments_id_assignments_id_fk": {
+          "name": "users_assignments_assignments_id_assignments_id_fk",
+          "tableFrom": "users_assignments",
+          "tableTo": "assignments",
+          "columnsFrom": [
+            "assignments_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_assignments_status_assignment_status_status_fk": {
+          "name": "users_assignments_status_assignment_status_status_fk",
+          "tableFrom": "users_assignments",
+          "tableTo": "assignment_status",
+          "columnsFrom": [
+            "status"
+          ],
+          "columnsTo": [
+            "status"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "users_assignments_users_id_assignments_id_pk": {
+          "name": "users_assignments_users_id_assignments_id_pk",
+          "columns": [
+            "users_id",
+            "assignments_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_status": {
+      "name": "users_status",
+      "schema": "",
+      "columns": {
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_administrator": {
+          "name": "is_administrator",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_team_id_teams_id_fk": {
+          "name": "users_team_id_teams_id_fk",
+          "tableFrom": "users",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_status_users_status_status_fk": {
+          "name": "users_status_users_status_status_fk",
+          "tableFrom": "users",
+          "tableTo": "users_status",
+          "columnsFrom": [
+            "status"
+          ],
+          "columnsTo": [
+            "status"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1749385560438,
       "tag": "0002_seed-user-status",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1749652301193,
+      "tag": "0003_clean_warbound",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,11 @@
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^5.0.1",
+        "@radix-ui/react-checkbox": "^1.3.2",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-select": "^2.2.2",
         "@radix-ui/react-slot": "^1.2.3",
+        "@radix-ui/react-tabs": "^1.1.12",
         "@supabase/ssr": "^0.6.1",
         "@supabase/supabase-js": "^2.49.8",
         "class-variance-authority": "^0.7.1",
@@ -1858,6 +1860,59 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.2.tgz",
+      "integrity": "sha512-yd+dI56KZqawxKZrJ31eENUwqc1QSqg4OZ15rybGjF2ZNwMO+wCyHzAVLRp9qoYJf7kYy0YpZ2b0JCzJ42HZpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-collection": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.6.tgz",
@@ -2134,6 +2189,30 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.4.tgz",
+      "integrity": "sha512-ueDqRbdc4/bkaQT3GIpLQssRlFgWaL/U2z/S31qRwwLWoxHLgry3SIfCwhxeQNbirEUXFa+lq3RL3oBYXtcmIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-primitive": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.2.tgz",
@@ -2171,6 +2250,86 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.10.tgz",
+      "integrity": "sha512-dT9aOXUen9JSsxnMPv/0VqySQf5eDQ6LCk5Sw28kamz8wSOW2bJdlX2Bg5VUIIcV+6XlHpWTIuTPCf/UNIyq8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -2250,6 +2409,59 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.12.tgz",
+      "integrity": "sha512-GTVAlRVrQrSw3cEARM0nAx73ixrWDPNZAruETn3oHCNP6SbZ/hNxdxp+u7VkIEv3/sFoLq1PfcHrl7Pnp0CDpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -17,12 +17,14 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.0.1",
+    "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-label": "^2.1.7",
+    "@radix-ui/react-select": "^2.2.2",
     "@radix-ui/react-slot": "^1.2.3",
+    "@radix-ui/react-tabs": "^1.1.12",
     "@supabase/ssr": "^0.6.1",
     "@supabase/supabase-js": "^2.49.8",
-    "@hookform/resolvers": "^5.0.1",
-    "@radix-ui/react-select": "^2.2.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "dotenv": "^16.5.0",
@@ -53,8 +55,8 @@
     "eslint-plugin-drizzle": "^0.2.3",
     "prettier": "^3.5.3",
     "tailwindcss": "^4",
-    "tw-animate-css": "^1.3.0",
     "tsx": "^4.19.4",
+    "tw-animate-css": "^1.3.0",
     "typescript": "^5",
     "vitest": "^3.1.3"
   },

--- a/src/app/admin/team-assignments/page.tsx
+++ b/src/app/admin/team-assignments/page.tsx
@@ -1,0 +1,359 @@
+"use client"
+
+import { useState } from "react"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/atoms/card"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/atoms/select"
+import { Button } from "@/components/atoms/button"
+import { Checkbox } from "@/components/atoms/checkbox"
+import { Badge } from "@/components/atoms/badge"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/atoms/tabs"
+import { Alert, AlertDescription } from "@/components/atoms/alert"
+import { CheckCircle, AlertCircle } from "lucide-react"
+
+// モックデータ
+const seasons = [
+  { id: "1", name: "1期" },
+  { id: "2", name: "2期" },
+]
+
+const teams = [
+  { id: "1-1", name: "チーム1-1", seasonId: "1" },
+  { id: "1-2", name: "チーム1-2", seasonId: "1" },
+  { id: "2-1", name: "チーム2-1", seasonId: "2" },
+  { id: "2-2", name: "チーム2-2", seasonId: "2" },
+]
+
+const tasks = [
+  { id: "1", title: "DBモデリング1", description: "...", genre: "データベース設計" },
+  { id: "2", title: "DBモデリング2", description: "...", genre: "データベース設計" },
+  { id: "3", title: "DBモデリング3", description: "...", genre: "データベース設計" },
+  { id: "4", title: "DBモデリング4", description: "...", genre: "データベース設計" },
+  { id: "5", title: "DBモデリング5", description: "...", genre: "データベース設計" },
+  { id: "6", title: "データベース設計のアンチパターンを学ぶ1", description: "...", genre: "データベース設計" },
+  { id: "7", title: "データベース設計のアンチパターンを学ぶ2", description: "...", genre: "データベース設計" },
+  { id: "8", title: "データベース設計のアンチパターンを学ぶ3", description: "...", genre: "データベース設計" },
+  { id: "9", title: "データベース設計のアンチパターンを学ぶ4", description: "...", genre: "データベース設計" },
+  { id: "10", title: "データベース設計のアンチパターンを学ぶ5", description: "...", genre: "データベース設計" },
+  { id: "11", title: "データベース設計のアンチパターンを学ぶ6", description: "...", genre: "データベース設計" },
+  { id: "12", title: "データベース設計のアンチパターンを学ぶ7", description: "...", genre: "データベース設計" },
+  { id: "13", title: "データベース設計のアンチパターンを学ぶ8", description: "...", genre: "データベース設計" },
+  { id: "14", title: "データベース設計のアンチパターンを学ぶ9", description: "...", genre: "データベース設計" },
+  { id: "15", title: "アンチパターンを踏まえてDBモデリングを見直そう", description: "...", genre: "データベース設計" },
+  { id: "16", title: "マルチテナントについて", description: "...", genre: "データベース設計" },
+  { id: "17", title: "外部キー制約について考える", description: "...", genre: "データベース設計" },
+  { id: "18", title: "データベースにおけるNULLの扱い", description: "...", genre: "データベース設計" },
+
+  { id: "19", title: "jestで単体テストを書こう", description: "...", genre: "テスト" },
+  { id: "20", title: "storybookを作ろう", description: "...", genre: "テスト" },
+  { id: "21", title: "スナップショットテストを書こう", description: "...", genre: "テスト" },
+  { id: "22", title: "ビジュアル・リグレッションテストを書こう", description: "...", genre: "テスト" },
+  { id: "23", title: "E2Eテストを書こう", description: "...", genre: "テスト" },
+  { id: "24", title: "TDD（テスト駆動開発）でコードを書いてみる", description: "...", genre: "テスト" },
+  { id: "25", title: "基本的な設計原則", description: "...", genre: "設計" },
+  { id: "26", title: "オニオンアーキテクチャを学ぶ", description: "...", genre: "設計" },
+  { id: "27", title: "DDDを学ぶ（基礎） ", description: "...", genre: "設計" },
+  { id: "28", title: "特大課題：プラハチャレンジ", description: "...", genre: "設計" },
+  { id: "29", title: "DDDを学ぶ（応用）", description: "...", genre: "設計" },
+  { id: "30", title: "リファクタリング", description: "...", genre: "設計" },
+  { id: "31", title: "SQL10本ノック", description: "...", genre: "データベース" },
+  { id: "32", title: "インデックスを理解する", description: "...", genre: "データベース" },
+  { id: "33", title: "スロークエリを理解する", description: "...", genre: "データベース" },
+  { id: "34", title: "ビューを使いこなす", description: "...", genre: "データベース" },
+  { id: "35", title: "トランザクションについて理解する", description: "...", genre: "データベース" },
+
+  { id: "36", title: "はじめに React ( Next.js ) の環境を立ち上げよう", description: "...", genre: "フロントエンド" },
+  { id: "37", title: "適切にコンポーネントを分割して1ページ作ってみよう", description: "...", genre: "フロントエンド" },
+  { id: "38", title: "作ったページをレスポンシブ対応しよう", description: "...", genre: "フロントエンド" },
+  { id: "39", title: "よくあるボタンコンポーネントを作成する", description: "...", genre: "フロントエンド" },
+  { id: "40", title: "再利用しやすいコンポーネントのcssを考える", description: "...", genre: "フロントエンド" },
+  { id: "41", title: "State hooks を理解して ToDo アプリを実装しよう", description: "...", genre: "フロントエンド" },
+  { id: "42", title: "Effect hookを理解する", description: "...", genre: "フロントエンド" },
+  { id: "43", title: "Refを理解する", description: "...", genre: "フロントエンド" },
+  { id: "44", title: "フロントエンドのレンダリングパターンを学ぶ", description: "...", genre: "フロントエンド" },
+  { id: "45", title: "外部ライブラリの存在を隠蔽する", description: "...", genre: "フロントエンド" },
+  { id: "46", title: "SWR/React Queryを理解する", description: "...", genre: "フロントエンド" },
+  { id: "47", title: "Suspense（旧Concurrent mode）を理解する", description: "...", genre: "フロントエンド" },
+
+  { id: "48", title: "よく使うHTTPヘッダを理解する", description: "...", genre: "WEBの基礎" },
+  { id: "49", title: "curlとpostmanに慣れる", description: "...", genre: "WEBの基礎" },
+  { id: "50", title: "リクエストをパースするWEBサーバを作ってみる", description: "...", genre: "WEBの基礎" },
+  { id: "51", title: "クッキーを理解する", description: "...", genre: "WEBの基礎" },
+  { id: "52", title: "サードパーティクッキーについて理解する", description: "...", genre: "WEBの基礎" },
+  { id: "53", title: "CORSについて理解する", description: "...", genre: "WEBの基礎" },
+  { id: "54", title: "キャッシュについて理解する", description: "...", genre: "WEBの基礎" },
+  { id: "55", title: "WEBサービスの代表的な脆弱性を理解する", description: "...", genre: "WEBの基礎" },
+
+
+  { id: "56", title: "linterを使おう", description: "...", genre: "チーム開発" },
+  { id: "57", title: "CI環境を整備してみよう", description: "...", genre: "チーム開発" },
+  { id: "58", title: "チーム開発を円滑にするコツを覚えよう", description: "...", genre: "チーム開発" },
+  { id: "59", title: "ブランチ戦略を学ぼう", description: "...", genre: "チーム開発" },
+  { id: "60", title: "アジャイル開発を学ぼう", description: "...", genre: "チーム開発" },
+  { id: "61", title: "Gitの便利コマンドを覚える", description: "...", genre: "チーム開発" },
+
+  { id: "62", title: "安全なIAMの設計を理解する", description: "...", genre: "クラウドインフラ" },
+  { id: "63", title: "マルチAZに跨るVPCを構築する", description: "...", genre: "クラウドインフラ" },
+  { id: "64", title: "冗長化されたWebアプリケーションを作ってみよう", description: "...", genre: "クラウドインフラ" },
+  { id: "65", title: "S3を理解する", description: "...", genre: "クラウドインフラ" },
+  { id: "66", title: "CDN(CloudFront)について理解して使ってみよう", description: "...", genre: "クラウドインフラ" },
+
+  { id: "67", title: "ログの取り方を学ぼう", description: "...", genre: "サービス運用" },
+  { id: "68", title: "本番稼働中のデータベースをマイグレーションしよう", description: "...", genre: "サービス運用" },
+  { id: "69", title: "サービスのモニタリングを考える", description: "...", genre: "サービス運用" },
+  { id: "70", title: "Dockerで環境差分を吸収する", description: "...", genre: "サービス運用" },
+
+  { id: "71", title: "外部APIを活用してみよう", description: "...", genre: "高速MVP開発" },
+  { id: "72", title: "MVP用フロントエンドを実装してみよう", description: "...", genre: "高速MVP開発" },
+  { id: "73", title: "ログイン機能を実装してみよう", description: "...", genre: "高速MVP開発" },
+  { id: "74", title: "BaaSを利用してバックエンドを実装・デプロイしてみよう", description: "...", genre: "高速MVP開発" },
+
+]
+
+// チームごとの課題割り当て状況（モック）
+const initialAssignments: { [key: string]: string[] } = {
+  "1-1": ["1", "2"],
+  "1-2": ["1", "2", "3"],
+  "2-1": ["1", "2", "3", "4"],
+  "2-2": ["1", "2", "3", "4", "5"],
+}
+
+export default function TeamAssignmentPage() {
+  const [selectedSeason, setSelectedSeason] = useState<string>("")
+  const [selectedTeam, setSelectedTeam] = useState<string>("")
+  const [assignments, setAssignments] = useState(initialAssignments)
+  const [successMessage, setSuccessMessage] = useState<string | null>(null)
+
+  // 選択されたシーズンに基づいてチームをフィルタリング
+  const filteredTeams = selectedSeason ? teams.filter((team) => team.seasonId === selectedSeason) : []
+
+  // チームが選択されたときの課題割り当て状況
+  const teamAssignments = selectedTeam ? assignments[selectedTeam] || [] : []
+
+  // 課題の割り当て状態を切り替える
+  const toggleTaskAssignment = (taskId: string) => {
+    setAssignments((prev) => {
+      const newAssignments = { ...prev }
+
+      if (!newAssignments[selectedTeam]) {
+        newAssignments[selectedTeam] = []
+      }
+
+      if (newAssignments[selectedTeam].includes(taskId)) {
+        newAssignments[selectedTeam] = newAssignments[selectedTeam].filter((id) => id !== taskId)
+      } else {
+        newAssignments[selectedTeam] = [...newAssignments[selectedTeam], taskId]
+      }
+
+      return newAssignments
+    })
+  }
+
+  // 変更を保存する
+  const saveChanges = () => {
+    // ここで実際のAPIリクエストを行う
+    console.log("保存された割り当て:", assignments)
+    setSuccessMessage("チームへの課題割り当てが保存されました")
+
+    // 3秒後にメッセージを消す
+    setTimeout(() => {
+      setSuccessMessage(null)
+    }, 3000)
+  }
+
+  return (
+    <div className="container mx-auto py-8">
+      <h1 className="text-3xl font-bold mb-6">チーム課題割り当て</h1>
+
+      {successMessage && (
+        <Alert className="mb-6 bg-green-50 border-green-200">
+          <CheckCircle className="h-4 w-4 text-green-600" />
+          <AlertDescription className="text-green-600">{successMessage}</AlertDescription>
+        </Alert>
+      )}
+
+      <div className="grid gap-6 md:grid-cols-12">
+        <div className="md:col-span-3">
+          <Card>
+            <CardHeader>
+              <CardTitle>フィルター</CardTitle>
+              <CardDescription>シーズンとチームを選択してください</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <label htmlFor="season" className="text-sm font-medium">
+                  シーズン
+                </label>
+                <Select
+                  value={selectedSeason}
+                  onValueChange={(value) => {
+                    setSelectedSeason(value)
+                    setSelectedTeam("")
+                  }}
+                >
+                  <SelectTrigger id="season">
+                    <SelectValue placeholder="シーズンを選択" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {seasons.map((season) => (
+                      <SelectItem key={season.id} value={season.id}>
+                        {season.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-2">
+                <label htmlFor="team" className="text-sm font-medium">
+                  チーム
+                </label>
+                <Select value={selectedTeam} onValueChange={setSelectedTeam} disabled={!selectedSeason}>
+                  <SelectTrigger id="team">
+                    <SelectValue placeholder="チームを選択" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {filteredTeams.map((team) => (
+                      <SelectItem key={team.id} value={team.id}>
+                        {team.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className="md:col-span-9">
+          <Card>
+            <CardHeader>
+              <CardTitle>
+                課題割り当て
+                {selectedTeam && (
+                  <span className="ml-2">
+                    <Badge variant="outline">{teams.find((t) => t.id === selectedTeam)?.name}</Badge>
+                  </span>
+                )}
+              </CardTitle>
+              <CardDescription>チームに割り当てる課題を選択してください</CardDescription>
+            </CardHeader>
+            <CardContent>
+              {!selectedTeam ? (
+                <div className="flex items-center justify-center h-64 border rounded-md border-dashed">
+                  <div className="text-center text-muted-foreground">
+                    <AlertCircle className="mx-auto h-12 w-12 mb-2 text-muted-foreground/50" />
+                    <p>シーズンとチームを選択してください</p>
+                  </div>
+                </div>
+              ) : (
+                <>
+                  <Tabs defaultValue="all" className="mb-6">
+                    <TabsList>
+                      <TabsTrigger value="all">すべての課題</TabsTrigger>
+                      <TabsTrigger value="assigned">割り当て済み</TabsTrigger>
+                      <TabsTrigger value="unassigned">未割り当て</TabsTrigger>
+                    </TabsList>
+                    <TabsContent value="all" className="mt-4">
+                      <div className="space-y-4">
+                        {tasks.map((task) => (
+                          <div
+                            key={task.id}
+                            className="flex items-start space-x-3 p-4 border rounded-md hover:bg-muted/50 transition-colors"
+                          >
+                            <Checkbox
+                              id={`task-${task.id}`}
+                              checked={teamAssignments.includes(task.id)}
+                              onCheckedChange={() => toggleTaskAssignment(task.id)}
+                            />
+                            <div className="flex-1">
+                              <label
+                                htmlFor={`task-${task.id}`}
+                                className="text-sm font-medium cursor-pointer flex items-center"
+                              >
+                                {task.title}
+                                <Badge variant="outline" className="ml-2 text-xs">
+                                  {task.genre}
+                                </Badge>
+                              </label>
+                              <p className="text-sm text-muted-foreground mt-1">{task.description}</p>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    </TabsContent>
+                    <TabsContent value="assigned" className="mt-4">
+                      <div className="space-y-4">
+                        {tasks
+                          .filter((task) => teamAssignments.includes(task.id))
+                          .map((task) => (
+                            <div
+                              key={task.id}
+                              className="flex items-start space-x-3 p-4 border rounded-md hover:bg-muted/50 transition-colors"
+                            >
+                              <Checkbox
+                                id={`task-assigned-${task.id}`}
+                                checked={true}
+                                onCheckedChange={() => toggleTaskAssignment(task.id)}
+                              />
+                              <div className="flex-1">
+                                <label
+                                  htmlFor={`task-assigned-${task.id}`}
+                                  className="text-sm font-medium cursor-pointer flex items-center"
+                                >
+                                  {task.title}
+                                  <Badge variant="outline" className="ml-2 text-xs">
+                                    {task.genre}
+                                  </Badge>
+                                </label>
+                                <p className="text-sm text-muted-foreground mt-1">{task.description}</p>
+                              </div>
+                            </div>
+                          ))}
+                      </div>
+                    </TabsContent>
+                    <TabsContent value="unassigned" className="mt-4">
+                      <div className="space-y-4">
+                        {tasks
+                          .filter((task) => !teamAssignments.includes(task.id))
+                          .map((task) => (
+                            <div
+                              key={task.id}
+                              className="flex items-start space-x-3 p-4 border rounded-md hover:bg-muted/50 transition-colors"
+                            >
+                              <Checkbox
+                                id={`task-unassigned-${task.id}`}
+                                checked={false}
+                                onCheckedChange={() => toggleTaskAssignment(task.id)}
+                              />
+                              <div className="flex-1">
+                                <label
+                                  htmlFor={`task-unassigned-${task.id}`}
+                                  className="text-sm font-medium cursor-pointer flex items-center"
+                                >
+                                  {task.title}
+                                  <Badge variant="outline" className="ml-2 text-xs">
+                                    {task.genre}
+                                  </Badge>
+                                </label>
+                                <p className="text-sm text-muted-foreground mt-1">{task.description}</p>
+                              </div>
+                            </div>
+                          ))}
+                      </div>
+                    </TabsContent>
+                  </Tabs>
+
+                  <div className="flex justify-end mt-6">
+                    <Button onClick={saveChanges} disabled={!selectedTeam}>
+                      変更を保存
+                    </Button>
+                  </div>
+                </>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/atoms/alert.tsx
+++ b/src/components/atoms/alert.tsx
@@ -1,0 +1,66 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const alertVariants = cva(
+  "relative w-full rounded-lg border px-4 py-3 text-sm grid has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] grid-cols-[0_1fr] has-[>svg]:gap-x-3 gap-y-0.5 items-start [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current",
+  {
+    variants: {
+      variant: {
+        default: "bg-card text-card-foreground",
+        destructive:
+          "text-destructive bg-card [&>svg]:text-current *:data-[slot=alert-description]:text-destructive/90",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Alert({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
+  return (
+    <div
+      data-slot="alert"
+      role="alert"
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn(
+        "col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDescription({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn(
+        "text-muted-foreground col-start-2 grid justify-items-start gap-1 text-sm [&_p]:leading-relaxed",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Alert, AlertTitle, AlertDescription }

--- a/src/components/atoms/badge.tsx
+++ b/src/components/atoms/badge.tsx
@@ -1,0 +1,46 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+        destructive:
+          "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        outline:
+          "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : "span"
+
+  return (
+    <Comp
+      data-slot="badge"
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/src/components/atoms/checkbox.tsx
+++ b/src/components/atoms/checkbox.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import * as React from "react"
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
+import { CheckIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="flex items-center justify-center text-current transition-none"
+      >
+        <CheckIcon className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/src/components/atoms/tabs.tsx
+++ b/src/components/atoms/tabs.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import { cn } from "@/lib/utils"
+
+function Tabs({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function TabsList({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      className={cn(
+        "bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn("flex-1 outline-none", className)}
+      {...props}
+    />
+  )
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/src/infra/schema.ts
+++ b/src/infra/schema.ts
@@ -15,12 +15,33 @@ export const usersStatusTable = pgTable("users_status", {
   status: varchar("status", { length: 50 }).primaryKey(),
 });
 
+// シーズンテーブル
+export const seasonsTable = pgTable("seasons", {
+  id: uuid("id").primaryKey(),
+  name: varchar("name", { length: 100 }).notNull(),
+  createdAt: timestamp("created_at").notNull().defaultNow(),
+  updatedAt: timestamp("updated_at").notNull().defaultNow(),
+});
+
+// チームテーブル
+export const teamsTable = pgTable("teams", {
+  id: uuid("id").primaryKey(),
+  name: varchar("name", { length: 255 }).notNull(),
+  seasonId: uuid("season_id")
+    .notNull()
+    .references(() => seasonsTable.id),
+  createdAt: timestamp("created_at").notNull().defaultNow(),
+  updatedAt: timestamp("updated_at").notNull().defaultNow(),
+});
+
 // ユーザーテーブル
 export const usersTable = pgTable("users", {
   id: uuid("id").primaryKey(),
   firstName: varchar("first_name", { length: 255 }).notNull(),
   lastName: varchar("last_name", { length: 255 }).notNull(),
-  season: integer("season").notNull(),
+  teamId: uuid("team_id")
+    .notNull()
+    .references(() => teamsTable.id),
   isAdministrator: boolean("is_administrator").notNull(),
   status: varchar("status", { length: 50 }).references(
     () => usersStatusTable.status,


### PR DESCRIPTION
## Issue
https://github.com/furusho99/praha-challenge-agile-dev/issues/25

## 対応内容
- シーズンテーブルとチームテーブルを作成。
- ユーザーテーブルのシーズンカラムをドロップし、テームIDカラムを追加。
- 課題公開ステータス変更画面の実装
  - http://localhost:3001/admin/team-assignments

## この PR でやらないこと
- APIとの連携
- コンポーネント設計

## スクショ(Optional)
![スクリーンショット 2025-06-12 0 17 51](https://github.com/user-attachments/assets/26e90334-3b68-447a-b0c3-76ad97612914)

Figma
https://www.figma.com/design/Bhtvsuadrg0ykQkiz5pbbS/Praha-Challenge?node-id=0-1&p=f&t=FAV3wRlCO5Bf7Gt8-0

## 影響範囲
特になし

## レビュー観点
- スキーマを変更しましたので、齟齬がないかご確認お願いします！
- 画面はイメージのすり合わせを主として、確認して欲しいです。
